### PR TITLE
Allow specifying target build stage

### DIFF
--- a/cmd/pulumi-resource-docker-buildkit/main.go
+++ b/cmd/pulumi-resource-docker-buildkit/main.go
@@ -232,6 +232,7 @@ func (k *dockerBuildkitProvider) dockerBuild(
 	baseName := strings.Split(name, ":")[0]
 	context := inputs["context"].StringValue()
 	dockerfile := inputs["dockerfile"].StringValue()
+	target := inputs["target"].StringValue()
 	registry := inputs["registry"].ObjectValue()
 	username := registry["username"]
 	password := registry["password"]
@@ -269,6 +270,7 @@ func (k *dockerBuildkitProvider) dockerBuild(
 		"--cache-from", name,
 		"--cache-to", "type=inline",
 		"-f", filepath.Join(context, dockerfile),
+		"--target", target,
 		"-t", name, "--push",
 		context,
 	)

--- a/cmd/pulumi-sdkgen-docker-buildkit/main.go
+++ b/cmd/pulumi-sdkgen-docker-buildkit/main.go
@@ -84,10 +84,15 @@ func run(version string) error {
 							Description: "The URL of the registry server hosting the image.",
 							TypeSpec:    schema.TypeSpec{Type: "string"},
 						},
+						"target": {
+							Description: "The name of the target stage to build in the Dockerfile.",
+							TypeSpec:    schema.TypeSpec{Type: "string"},
+						},
 					},
 					Required: []string{
 						"dockerfile", "context", "name", "platforms",
 						"contextDigest", "repoDigest", "registryServer",
+						"target",
 					},
 				},
 				InputProperties: map[string]schema.PropertySpec{
@@ -117,6 +122,11 @@ func run(version string) error {
 							Type:  "array",
 							Items: &schema.TypeSpec{Type: "string"},
 						},
+					},
+					"target": {
+						Description: "The name of the target stage to build in the Dockerfile.",
+						TypeSpec:    schema.TypeSpec{Type: "string"},
+						Default:     "",
 					},
 				},
 				RequiredInputs: []string{"name", "registry"},


### PR DESCRIPTION
This allows a single Dockerfile to be used for building multiple images, and reusing layers from the other stages.