### PR TITLE
Make username and password optional for Registry

### DIFF
--- a/cmd/pulumi-sdkgen-docker-buildkit/main.go
+++ b/cmd/pulumi-sdkgen-docker-buildkit/main.go
@@ -151,7 +151,7 @@ func run(version string) error {
 							TypeSpec:    schema.TypeSpec{Type: "string"},
 						},
 					},
-					Required: []string{"server", "username", "password"},
+					Required: []string{"server"},
 				},
 			},
 		},


### PR DESCRIPTION
Hello !

I'm trying to use your package with GCP instead of AWS, and `docker` is usually configured through `gcloud` instead of a username/password combo. Moreover, in your code if the username and password aren't specified no login is attempted, which would be the expected behavior (see https://github.com/MaterializeInc/pulumi-docker-buildkit/blob/master/cmd/pulumi-resource-docker-buildkit/main.go#L245).

I tested it myself against GCP Artifact Registry and it works well.

I'm not sure if you're open to that kind of small contributions, I hope you do, and otherwise I'll just maintain my fork I think.

Thanks !