### PR TITLE
Mark the "password" repo property as a Secret

### DIFF
--- a/cmd/pulumi-sdkgen-docker-buildkit/main.go
+++ b/cmd/pulumi-sdkgen-docker-buildkit/main.go
@@ -158,6 +158,7 @@ func run(version string) error {
 						"password": {
 							Description: "The password to authenticate with.",
 							TypeSpec:    schema.TypeSpec{Type: "string"},
+							Secret:      true,
 						},
 					},
 					Required: []string{"server"},


### PR DESCRIPTION
This should prevent the password from ending up in state dumps unmasked.