### PR TITLE
Skip reading of non-regular files

### DIFF
--- a/cmd/pulumi-resource-docker-buildkit/main.go
+++ b/cmd/pulumi-resource-docker-buildkit/main.go
@@ -475,9 +475,12 @@ func hashContext(contextPath string, dockerfile string) (string, error) {
 		if err != nil {
 			return fmt.Errorf("determining mode for %q: %w", path, err)
 		}
-		err = ch.hashPath(path, info.Mode())
-		if err != nil {
-			return fmt.Errorf("hashing %q: %w", path, err)
+		mode := info.Mode()
+		if mode.IsRegular() || mode == fs.ModeSymlink {
+			err = ch.hashPath(path, info.Mode())
+			if err != nil {
+				return fmt.Errorf("hashing %q: %w", path, err)
+			 }
 		}
 		return nil
 	})


### PR DESCRIPTION
If the build context directory contains named pipes, unix sockets, or other special files, the provider will try to read them and hang.